### PR TITLE
Some Markdown tools want an empty line before a list

### DIFF
--- a/lyon-amendment.md
+++ b/lyon-amendment.md
@@ -24,6 +24,7 @@ Enterprise Linux and CentOS v7 leave their maintenance support phase, even
 though v5.16.0 was released more than 10 years ago today.
 
 The toolchain is generally understood, here, to include:
+
 * CPAN
 * CPAN-Meta
 * ExtUtils-CBuilder


### PR DESCRIPTION
For example, see http://cpan.io/ref/toolchain/lyon-amendment.html which was generated automatically from this repository when this file was created.